### PR TITLE
Correct missing export and import for loadAllEarthquakeQueryParams function

### DIFF
--- a/docs/examples/helicorder/controls.js
+++ b/docs/examples/helicorder/controls.js
@@ -378,7 +378,7 @@ function updateEarthquakeQueryParam(currentConfig, id, defaultValue) {
     .querySelector("input#"+id).value = currentConfig[id];
 };
 
-function loadAllEarthquakeQueryParams(currentConfig) {
+export function loadAllEarthquakeQueryParams(currentConfig) {
   loadEarthquakeQueryParam(currentConfig, 'localMinLat');
   loadEarthquakeQueryParam(currentConfig, 'localMaxLat');
   loadEarthquakeQueryParam(currentConfig, 'localMinLon');

--- a/docs/examples/helicorder/heli.js
+++ b/docs/examples/helicorder/heli.js
@@ -1,6 +1,6 @@
 import * as sp from '../../seisplotjs_3.1.1_standalone.mjs';
 import {HOURS_PER_LINE, doPlot, queryEarthquakes, redrawHeli, getNowTime, drawSeismograph} from './doplot.js';
-import {updatePageForConfig, setupEventHandlers, enableFiltering} from './controls.js';
+import {updatePageForConfig, setupEventHandlers, enableFiltering, loadAllEarthquakeQueryParams,} from './controls.js';
 
 const d3 = sp.d3;
 const luxon = sp.luxon;


### PR DESCRIPTION
The Refresh Earthquake button needs the loadAllEarthquakeQueryParams function to exported and imported in order to update the changes in the input fields.