### PR TITLE
Replace Error Value

### DIFF
--- a/src/miniseed.ts
+++ b/src/miniseed.ts
@@ -595,10 +595,12 @@ export function createSeismogramSegment(
  * when getting data from the same channel for multiple earthquakes.
  *
  * @param drList array of data records
+ * @param maxValue if set, replaces all values equal to this with replaceValue
+ * @param replaceValue if set, replaces all values equal to maxValue with this value.
  * @returns Seismogram instance
  */
-export function merge(drList: Array<DataRecord>): Seismogram {
-  return new Seismogram(mergeSegments(drList));
+export function merge(drList: Array<DataRecord>, maxValue?: number, replaceValue?: number): Seismogram {
+  return new Seismogram(mergeSegments(drList), maxValue, replaceValue);
 }
 
 /**
@@ -691,13 +693,17 @@ export function seismogramSegmentPerChannel(
  * Seismogram for each channel.
  *
  * @param   drList DataRecords array
+ * @param   maxValue if set, replaces all values equal to this with replaceValue
+ * @param   replaceValue if set, replaces all values equal to maxValue with this value.
  * @returns         Array of Seismogram
  */
 export function seismogramPerChannel(
   drList: Array<DataRecord>,
+  maxValue?: number,
+  replaceValue?: number,
 ): Array<Seismogram> {
   const out: Array<Seismogram> = [];
   const byChannelMap = byChannel(drList);
-  byChannelMap.forEach((segments) => out.push(merge(segments)));
+  byChannelMap.forEach((segments) => out.push(merge(segments, maxValue, replaceValue)));
   return out;
 }

--- a/src/miniseed.ts
+++ b/src/miniseed.ts
@@ -560,10 +560,14 @@ export function areContiguous(dr1: DataRecord, dr2: DataRecord): boolean {
  * DataRecord are used.
  *
  * @param contig array of data records
+ * @param maxValue if set, replaces all values equal to this with replaceValue
+ * @param replaceValue if set, replaces all values equal to maxValue with this value.
  * @returns SeismogramSegment instance
  */
 export function createSeismogramSegment(
   contig: Array<DataRecord> | DataRecord,
+  maxValue?: number,
+  replaceValue?: number,
 ): SeismogramSegment {
   if (!Array.isArray(contig)) {
     contig = [contig];
@@ -580,6 +584,8 @@ export function createSeismogramSegment(
       contig[0].header.locCode,
       contig[0].header.chanCode,
     ),
+    maxValue,
+    replaceValue,
   );
   return out;
 }
@@ -600,17 +606,21 @@ export function createSeismogramSegment(
  * @returns Seismogram instance
  */
 export function merge(drList: Array<DataRecord>, maxValue?: number, replaceValue?: number): Seismogram {
-  return new Seismogram(mergeSegments(drList), maxValue, replaceValue);
+  return new Seismogram(mergeSegments(drList, maxValue, replaceValue));
 }
 
 /**
  * merges contiguous DataRecords into SeismogramSegments.
  *
  * @param drList array of data records
+ * @param maxValue if set, replaces all values equal to this with replaceValue
+ * @param replaceValue if set, replaces all values equal to maxValue with this value.
  * @returns array of SeismogramSegments for contiguous data
  */
 export function mergeSegments(
   drList: Array<DataRecord>,
+  maxValue?: number,
+  replaceValue?: number,
 ): Array<SeismogramSegment> {
   const out = [];
   let currDR;
@@ -628,14 +638,14 @@ export function mergeSegments(
       contig.push(currDR);
     } else {
       //found a gap
-      out.push(createSeismogramSegment(contig));
+      out.push(createSeismogramSegment(contig, maxValue, replaceValue));
       contig = [currDR];
     }
   }
 
   if (contig.length > 0) {
     // last segment
-    out.push(createSeismogramSegment(contig));
+    out.push(createSeismogramSegment(contig, maxValue, replaceValue));
     contig = [];
   }
 
@@ -676,15 +686,19 @@ export function byChannel(
  * SeismogramSegment for each contiguous window from each channel.
  *
  * @param   drList DataRecords array
+ * @param   maxValue if set, replaces all values equal to this with replaceValue
+ * @param   replaceValue if set, replaces all values equal to maxValue with this value
  * @returns         Array of SeismogramSegment
  */
 export function seismogramSegmentPerChannel(
   drList: Array<DataRecord>,
+  maxValue?: number,
+  replaceValue?: number,
 ): Array<SeismogramSegment> {
   let out = new Array<SeismogramSegment>(0);
   const byChannelMap = byChannel(drList);
   byChannelMap.forEach(
-    (segments) => (out = out.concat(mergeSegments(segments))),
+    (segments) => (out = out.concat(mergeSegments(segments, maxValue, replaceValue))),
   );
   return out;
 }

--- a/src/seismogram.ts
+++ b/src/seismogram.ts
@@ -49,10 +49,13 @@ export class Seismogram {
   _segmentArray: Array<SeismogramSegment>;
   _interval: Interval;
   _y: null | Int32Array | Float32Array | Float64Array;
+  maxAmplitudeValue: number | null;
+  replaceAmplitudeValue: number;
 
-  constructor(segmentArray: SeismogramSegment | Array<SeismogramSegment>) {
+  constructor(segmentArray: SeismogramSegment | Array<SeismogramSegment>, maxValue?: number, replaceValue?: number) {
     this._y = null;
-
+    this.maxAmplitudeValue = maxValue || null;
+    this.replaceAmplitudeValue = replaceValue || 0;
     if (
       Array.isArray(segmentArray) &&
       segmentArray[0] instanceof SeismogramSegment
@@ -368,17 +371,18 @@ export class Seismogram {
    * Merges all segments into a single array of the same type as the first
    * segment. No checking is done for gaps or overlaps, this is a simple
    * congatination. Be careful!
-   *
    * @returns contatenated data
    */
   merge(): Int32Array | Float32Array | Float64Array {
     let outArray: Int32Array | Float32Array | Float64Array;
 
+
     let idx = 0;
     if (this._segmentArray.every((seg) => seg.y instanceof Int32Array)) {
       outArray = new Int32Array(this.numPoints);
       this._segmentArray.forEach((seg) => {
-        outArray.set(seg.y, idx);
+        const y = this.maxAmplitudeValue ? seg.y.map((v) => v === this.maxAmplitudeValue ? this.replaceAmplitudeValue : v) : seg.y;
+        outArray.set(y, idx);
         idx += seg.y.length;
       });
     } else if (
@@ -386,7 +390,8 @@ export class Seismogram {
     ) {
       outArray = new Float32Array(this.numPoints);
       this._segmentArray.forEach((seg) => {
-        outArray.set(seg.y, idx);
+        const y = this.maxAmplitudeValue ? seg.y.map((v) => v === this.maxAmplitudeValue ? this.replaceAmplitudeValue : v) : seg.y;
+        outArray.set(y, idx);
         idx += seg.y.length;
       });
     } else if (
@@ -394,7 +399,8 @@ export class Seismogram {
     ) {
       outArray = new Float64Array(this.numPoints);
       this._segmentArray.forEach((seg) => {
-        outArray.set(seg.y, idx);
+        const y = this.maxAmplitudeValue ? seg.y.map((v) => v === this.maxAmplitudeValue ? this.replaceAmplitudeValue : v) : seg.y;
+        outArray.set(y, idx);
         idx += seg.y.length;
       });
     } else {

--- a/src/seismogram.ts
+++ b/src/seismogram.ts
@@ -49,13 +49,9 @@ export class Seismogram {
   _segmentArray: Array<SeismogramSegment>;
   _interval: Interval;
   _y: null | Int32Array | Float32Array | Float64Array;
-  maxAmplitudeValue: number | null;
-  replaceAmplitudeValue: number;
 
-  constructor(segmentArray: SeismogramSegment | Array<SeismogramSegment>, maxValue?: number, replaceValue?: number) {
+  constructor(segmentArray: SeismogramSegment | Array<SeismogramSegment>) {
     this._y = null;
-    this.maxAmplitudeValue = maxValue || null;
-    this.replaceAmplitudeValue = replaceValue || 0;
     if (
       Array.isArray(segmentArray) &&
       segmentArray[0] instanceof SeismogramSegment
@@ -381,8 +377,7 @@ export class Seismogram {
     if (this._segmentArray.every((seg) => seg.y instanceof Int32Array)) {
       outArray = new Int32Array(this.numPoints);
       this._segmentArray.forEach((seg) => {
-        const y = this.maxAmplitudeValue ? seg.y.map((v) => v === this.maxAmplitudeValue ? this.replaceAmplitudeValue : v) : seg.y;
-        outArray.set(y, idx);
+        outArray.set(seg.y, idx);
         idx += seg.y.length;
       });
     } else if (
@@ -390,8 +385,7 @@ export class Seismogram {
     ) {
       outArray = new Float32Array(this.numPoints);
       this._segmentArray.forEach((seg) => {
-        const y = this.maxAmplitudeValue ? seg.y.map((v) => v === this.maxAmplitudeValue ? this.replaceAmplitudeValue : v) : seg.y;
-        outArray.set(y, idx);
+        outArray.set(seg.y, idx);
         idx += seg.y.length;
       });
     } else if (
@@ -399,8 +393,7 @@ export class Seismogram {
     ) {
       outArray = new Float64Array(this.numPoints);
       this._segmentArray.forEach((seg) => {
-        const y = this.maxAmplitudeValue ? seg.y.map((v) => v === this.maxAmplitudeValue ? this.replaceAmplitudeValue : v) : seg.y;
-        outArray.set(y, idx);
+        outArray.set(seg.y, idx);
         idx += seg.y.length;
       });
     } else {


### PR DESCRIPTION
We can replace error value while parsing data. This very usefull some time our semimologger send random or wrong data which spike our graph and not able to see properly so, you can replace that with 0 or other number.

```
const parse = sp.miniseed.parseDataRecords(response.data)
const _dd = sp.miniseed.seismogramPerChannel(parse, 1000, 0)
```
there is a way of using this, if possible please merge and push to npm, 
if your not going to merge please create new alpha and push to the npm, i like to use this function